### PR TITLE
Added Translation for "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater"

### DIFF
--- a/custom_components/home_connect_alt/translations/cs.json
+++ b/custom_components/home_connect_alt/translations/cs.json
@@ -253,6 +253,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "Espresso",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "Espresso Doppio",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "Espresso Macchiato",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "Horúca voda",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "Latte Macchiato",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "Mléčná pěna",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "Ristretto",

--- a/custom_components/home_connect_alt/translations/de.json
+++ b/custom_components/home_connect_alt/translations/de.json
@@ -253,6 +253,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "Espresso",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "Espresso doppio",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "Espresso Macchiato",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "Heißes Wasser",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "Latte Macchiato",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "Milchschaum",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "Ristretto",

--- a/custom_components/home_connect_alt/translations/en.json
+++ b/custom_components/home_connect_alt/translations/en.json
@@ -224,6 +224,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "Espresso",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "Espresso Doppio",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "Espresso Macchiato",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "Hot Water",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "Latte Macchiato",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "Milk Froth",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "Ristretto",

--- a/custom_components/home_connect_alt/translations/he.json
+++ b/custom_components/home_connect_alt/translations/he.json
@@ -253,6 +253,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "אספרסו",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "אספרסו דופיו",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "אספרסו מקיאטו",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "מים חמים",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "לאטה מקיאטו",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "חלב מוקצף",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "ריסטרטו",

--- a/custom_components/home_connect_alt/translations/nl.json
+++ b/custom_components/home_connect_alt/translations/nl.json
@@ -253,6 +253,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "Espresso",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "Dubbele Espresso",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "Espresso Macchiato",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "Heet water",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "Latte Macchiato",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "Melkschuim",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "Ristretto",

--- a/custom_components/home_connect_alt/translations/pl.json
+++ b/custom_components/home_connect_alt/translations/pl.json
@@ -253,6 +253,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "Espresso",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "Espresso Doppio",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "Espresso Macchiato",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "Gorąca woda",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "Latte Macchiato",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "Pianka Mleczna",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "Ristretto",

--- a/custom_components/home_connect_alt/translations/sv.json
+++ b/custom_components/home_connect_alt/translations/sv.json
@@ -253,6 +253,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "Espresso",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "Espresso Doppio",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "Espresso Macchiato",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "Varmt vatten",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "Latte Macchiato",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "Mjulkskum",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "Ristretto",

--- a/custom_components/home_connect_alt/translations/zh.json
+++ b/custom_components/home_connect_alt/translations/zh.json
@@ -253,6 +253,7 @@
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso": "濃縮咖啡",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoDoppio": "雙份濃縮咖啡",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato": "濃縮瑪奇朵",
+          "ConsumerProducts.CoffeeMaker.Program.Beverage.HotWater": "热水",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato": "拿鐵瑪奇朵",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.MilkFroth": "牛奶奶泡",
           "ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto": "短萃濃縮咖啡",


### PR DESCRIPTION
maybe _cs, pl, nl, he, sv, zh_ needs to be crosschecked, since I used Google Translate and I am not sure, if the translation would make sense... Several translation files use the english wording for the programs...
