### PR TITLE
Absolute_delayed_time

### DIFF
--- a/custom_components/home_connect_alt/__init__.py
+++ b/custom_components/home_connect_alt/__init__.py
@@ -65,7 +65,7 @@ OPTIONS_SCHEMA = vol.Schema(
 )
 
 # For your initial PR, limit it to 1 platform.
-PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON, Platform.SWITCH, Platform.TIME]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/home_connect_alt/__init__.py
+++ b/custom_components/home_connect_alt/__init__.py
@@ -52,19 +52,18 @@ CONFIG_SCHEMA = vol.Schema(
 
 OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_CACHE, default=False): vol.Coerce(bool),
-        vol.Optional(CONF_LANG, default=CONF_LANG_DEFAULT): str,
+        vol.Optional(CONF_LANG, default=CONF_LANG_DEFAULT): vol.Coerce(str),
         vol.Optional(CONF_TRANSLATION_MODE, default="local"): vol.Coerce(str),
-        vol.Optional(CONF_SENSORS_TRANSLATION, default=None): vol.Any(str, None),
+        vol.Optional(CONF_DELAYED_OPS, default=CONF_DELAYED_OPS_DEFAULT): vol.Coerce(str),
         vol.Optional(CONF_NAME_TEMPLATE, default=CONF_NAME_TEMPLATE_DEFAULT): vol.Coerce(str),
         vol.Optional(CONF_LOG_MODE, default=0): vol.Coerce(int),
         vol.Optional(CONF_SSE_TIMEOUT, default=CONF_SSE_TIMEOUT_DEFAULT): vol.Coerce(int),
         vol.Optional(CONF_ENTITY_SETTINGS, default={}): vol.Any(dict, None),
         vol.Optional(CONF_APPLIANCE_SETTINGS, default={}): vol.Any(dict, None)
-    }
+    },
+    extra=vol.REMOVE_EXTRA
 )
 
-# For your initial PR, limit it to 1 platform.
 PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON, Platform.SWITCH, Platform.TIME]
 
 

--- a/custom_components/home_connect_alt/config_flow.py
+++ b/custom_components/home_connect_alt/config_flow.py
@@ -138,7 +138,7 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
     ) -> FlowResult:
         """ Manage the options """
         if user_input is not None:
-            #self.hass.data[DOMAIN].update(user_input)
+            # Save the config entry when the user input has been received
             return self.async_create_entry(title="", data=user_input)
 
         data_schema = {
@@ -147,8 +147,17 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                 selector({
                     "select": {
                         "options": CONF_TRANSLATION_MODES,
-                        "mode": "dropdown",
+                        #"mode": "dropdown",
                         "translation_key": CONF_TRANSLATION_MODE
+                    },
+                }),
+            # vol.Optional(CONF_ABSOLUTE_DELAYED_OPS, default=False): cv.boolean,
+            vol.Optional(CONF_DELAYED_OPS, default=CONF_DELAYED_OPS_DEFAULT):
+                selector({
+                    "select": {
+                        "options": [CONF_DELAYED_OPS_DEFAULT, CONF_DELAYED_OPS_ABSOLUTE_TIME],
+                        "mode": "list",
+                        "translation_key": CONF_DELAYED_OPS
                     },
                 }),
             vol.Optional(CONF_LOG_MODE, default=0): vol.All(int, vol.Range(min=0, max=7)),
@@ -166,12 +175,6 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                         selector({
                             "object": {}
                         }),
-                    # vol.Optional(CONF_APPLIANCE_SETTINGS): selector({
-                    #     "device": {
-                    #         "entity": [ {"integration": DOMAIN}],
-                    #         "multiple": True,
-                    #     }
-                    # }),
                 }
             )
 
@@ -181,5 +184,6 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         data_schema = self.add_suggested_values_to_schema(data_schema=vol.Schema(data_schema), suggested_values=defaults)
 
         return self.async_show_form(step_id="init", data_schema=data_schema)
+
 
 

--- a/custom_components/home_connect_alt/const.py
+++ b/custom_components/home_connect_alt/const.py
@@ -28,8 +28,9 @@ CONF_SSE_TIMEOUT = "sse_timeout"
 CONF_SSE_TIMEOUT_DEFAULT = 15
 CONF_ENTITY_SETTINGS = "entity_settings"
 CONF_APPLIANCE_SETTINGS = "appliance_settings"
-
-
+CONF_DELAYED_OPS = "delayed_ops"
+CONF_DELAYED_OPS_DEFAULT = "default"
+CONF_DELAYED_OPS_ABSOLUTE_TIME = "absolute_time"
 
 HOME_CONNECT_DEVICE = {
     "identifiers": {(DOMAIN, "homeconnect")},

--- a/custom_components/home_connect_alt/time.py
+++ b/custom_components/home_connect_alt/time.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+import logging
+import datetime
+from  homeassistant.components.time import TimeEntity, time, timedelta
+from home_connect_async import Appliance, HomeConnect, HomeConnectError, Events, ConditionalLogger as CL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType
+
+from .common import InteractiveEntityBase, EntityManager, is_boolean_enum, Configuration
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass:HomeAssistant , config_entry:ConfigType, async_add_entities:AddEntitiesCallback) -> None:
+    """Add Selects for passed config_entry in HA."""
+    entry_conf:Configuration = hass.data[DOMAIN][config_entry.entry_id]
+    homeconnect:HomeConnect = entry_conf["homeconnect"]
+    entity_manager = EntityManager(async_add_entities)
+
+    def add_appliance(appliance:Appliance) -> None:
+        conf = entry_conf.get_config()
+
+        if appliance.available_programs:
+            for program in appliance.available_programs.values():
+                if program.options:
+                    for option in program.options.values():
+                        if conf.get_entity_setting(option.key, "type") == "DelayedOperation":
+                            device = DelayedOperationTime(appliance, option.key, conf, option)
+                            entity_manager.add(device)
+
+        entity_manager.register()
+
+    def remove_appliance(appliance:Appliance) -> None:
+        entity_manager.remove_appliance(appliance)
+
+    homeconnect.register_callback(add_appliance, [Events.PAIRED, Events.DATA_CHANGED, Events.PROGRAM_STARTED, Events.PROGRAM_SELECTED])
+    homeconnect.register_callback(remove_appliance, Events.DEPAIRED)
+    for appliance in homeconnect.appliances.values():
+        add_appliance(appliance)
+
+
+class DelayedOperationTime(InteractiveEntityBase, TimeEntity):
+    """ Class for setting delayed start by the program end time """
+    should_poll = True
+
+    def __init__(self, appliance: Appliance, key: str = None, conf: dict = None, hc_obj = None) -> None:
+        super().__init__(appliance, key, conf, hc_obj)
+        self._current:time = self.init_time()
+
+    @property
+    def name_ext(self) -> str|None:
+        return self._hc_obj.name if self._hc_obj.name else "Delayed operation"
+
+    @property
+    def icon(self) -> str:
+        return self.get_entity_setting('icon', 'mdi:clock-outline')
+
+
+    @property
+    def available(self) -> bool:
+
+        # We must have the program run time for this entity to work
+        available = super().program_option_available and self.get_program_run_time()
+
+        if not available:
+            self._appliance.clear_startonly_option(self._key)
+        return available
+
+    async def async_set_value(self, value: time) -> None:
+        """Update the current value."""
+        self._current = self.adjust_time(value, True)
+
+        #self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> time:
+        """Return the entity value to represent the entity state."""
+        if self._appliance.startonly_options and self._key in self._appliance.startonly_options:
+            self._current = self.adjust_time(self._current, True)
+        else:
+            self._current = self.adjust_time(self._current, False)
+        return self._current
+
+    def adjust_time(self, t:time, set_option:bool) -> time:
+
+        now = datetime.datetime.now()
+        endtime = datetime.datetime(year=now.year, month=now.month, day=now.day, hour=t.hour, minute=t.minute)
+
+        if (now.hour > endtime.hour) or (now.hour == endtime.hour and now.minute > endtime.minute):
+            # if the specified time is smaller than now then it means tomorrow
+            endtime += datetime.timedelta(days=1)
+
+        program_run_time = self.get_program_run_time()
+
+        if endtime < now + timedelta(seconds=program_run_time):
+            # the set end time is closer then the program run time so change it to the expected end of the program
+            # and cancel the set delay option
+            endtime = now + timedelta(seconds=program_run_time)
+            #self._current = time(hour=endtime.hour, minute=endtime.minute)
+            _LOGGER.debug("Clearing startonly option %s", self._key)
+            self._appliance.clear_startonly_option(self._key)
+        elif set_option:
+            delay = (endtime-now).total_seconds()
+            if "StartInRelative" in self._key:
+                delay -= program_run_time
+
+            # round the delay to the stepsize
+            stepsize_option = self._appliance.get_applied_program_available_option(self._key)
+            stepsize = stepsize_option.stepsize if stepsize_option else 60
+            delay = int(delay/stepsize)*stepsize
+
+            _LOGGER.debug("Setting startonly option %s to: %i", self._key, delay)
+            self._appliance.set_startonly_option(self._key, delay)
+
+        return time(hour=endtime.hour, minute=endtime.minute)
+
+    def init_time(self) -> time:
+        inittime = datetime.datetime.now() + timedelta(minutes=1)
+        t = time(hour=inittime.hour, minute=inittime.minute)
+        return self.adjust_time(t, False)
+
+    def get_program_run_time(self) -> int|None:
+
+        # There seems to be a bug in HC which returns the remaining time for the previous program when there isn't an dactive one
+        prog_time_option = self._appliance.get_applied_program_option("BSH.Common.Option.RemainingProgramTime")
+        if prog_time_option and self._appliance.active_program:
+            return prog_time_option.value
+
+        prog_time_option = self._appliance.get_applied_program_option("BSH.Common.Option.FinishInRelative")
+        if prog_time_option:
+            return prog_time_option.value
+
+        prog_time_option = self._appliance.get_applied_program_option("BSH.Common.Option.EstimatedTotalProgramTime")
+        if prog_time_option:
+            return prog_time_option.value
+
+        return None
+
+
+    async def async_on_update(self, appliance:Appliance, key:str, value) -> None:
+        # reset the end time clock when a different program is selected
+        if key == Events.PROGRAM_SELECTED:
+            self._current = self.init_time()
+        self.async_write_ha_state()

--- a/custom_components/home_connect_alt/translations/cs.json
+++ b/custom_components/home_connect_alt/translations/cs.json
@@ -45,14 +45,16 @@
           "log_mode": "Verbose log režim",
           "sse_timeout": "SSE Timeout",
           "appliance_settings": "Advanced appliance settings (YAML)",
-          "entity_settings": "Advanced entity settings (YAML)"
+          "entity_settings": "Advanced entity settings (YAML)",
+          "delayed_ops": "Delayed start behavior"
         },
         "data_description": {
           "language": "Používejte pouze [kódy jazyků](https://api-docs.home-connect.com/general/#supported-languages) podporované službou Home Connect.",
           "log_mode": "Aby se toto nastavení použilo, musí být v souboru configuration.yaml povoleno protokolování ladění.",
           "sse_timeout": "Timeout in minutes for refreshing the SSE connection (0=disabled)",
           "appliance_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         }
       }
     }
@@ -71,6 +73,12 @@
       "options": {
         "local": "Lokální",
         "server": "Server"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "Use delay time span (default behavior)",
+        "absolute_time": "Use absolute time"
       }
     }
   },

--- a/custom_components/home_connect_alt/translations/de.json
+++ b/custom_components/home_connect_alt/translations/de.json
@@ -45,14 +45,16 @@
           "log_mode": "Verbose log mode",
           "sse_timeout": "SSE Timeout",
           "appliance_settings": "Advanced appliance settings (YAML)",
-          "entity_settings": "Advanced entity settings (YAML)"
+          "entity_settings": "Advanced entity settings (YAML)",
+          "delayed_ops": "Delayed start behavior"
         },
         "data_description": {
           "language": "Only use [language codes](https://api-docs.home-connect.com/general/#supported-languages) supported by Home Connect",
           "log_mode": "Debug logging must be enabled in configuration.yaml for this setting to apply",
           "sse_timeout": "Timeout in minutes for refreshing the SSE connection (0=disabled)",
           "appliance_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         }
       }
     }
@@ -71,6 +73,12 @@
       "options": {
         "local": "Local",
         "server": "Server"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "Use delay time span (default behavior)",
+        "absolute_time": "Use absolute time"
       }
     }
   },

--- a/custom_components/home_connect_alt/translations/en.json
+++ b/custom_components/home_connect_alt/translations/en.json
@@ -46,14 +46,16 @@
           "sse_timeout": "SSE timeout",
           "translation_mode": "Translation mode",
           "appliance_settings": "Advanced appliance settings (YAML)",
-          "entity_settings": "Advanced entity settings (YAML)"
+          "entity_settings": "Advanced entity settings (YAML)",
+          "delayed_ops": "Delayed start behavior"
         },
         "data_description": {
           "language": "Only use [language codes](https://api-docs.home-connect.com/general/#supported-languages) supported by Home Connect",
           "log_mode": "Debug logging must be enabled in configuration.yaml for this setting to apply",
           "sse_timeout": "Timeout for refreshing the SSE connection (0=disabled)",
           "appliance_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         },
         "description": "Review the configuration section in the [README](https://github.com/ekutner/home-connect-hass) for explanation of these settings",
         "title": "Advanced settings"
@@ -71,6 +73,12 @@
       "options": {
         "local": "Local",
         "server": "Server"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "Use delay time span (default behavior)",
+        "absolute_time": "Use absolute time"
       }
     }
   },

--- a/custom_components/home_connect_alt/translations/he.json
+++ b/custom_components/home_connect_alt/translations/he.json
@@ -45,14 +45,16 @@
           "log_mode": "מצב כתיבת לוג",
           "sse_timeout": "SSE חידוש קשר",
           "appliance_settings": "הגדרות מכשיר מתקדמות (YAML)",
-          "entity_settings": "הגדרות ישות מתקדמות (YAML)"
+          "entity_settings": "הגדרות ישות מתקדמות (YAML)",
+          "delayed_ops": "התנהגות של הפעלה עתידית"
         },
         "data_description": {
           "language": "יש להשתמש רק [בקודי שפה](https://api-docs.home-connect.com/general/#supported-languages) הנתמכים על ידי Home Connect",
           "log_mode": "יש להפעיל כתיבת לוג דיבאג בקובץ configuration.yaml כדי שהגדרה זו תפעל",
           "sse_timeout": "זמן, בדקות, לחידוש קשר SSE (0=כבוי)",
           "appliance_settings": "מידע מפורט ב-[README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "מידע מפורט ב-[README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "מידע מפורט ב-[README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "מידע נוסף ב-[README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         }
       }
     }
@@ -71,6 +73,12 @@
       "options": {
         "local": "מקומי",
         "server": "שרת"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "שימוש במשך זמן הדחיה (ההתנהגות הרגילה)",
+        "absolute_time": "שימוש בזמן אבסולוטי"
       }
     }
   },

--- a/custom_components/home_connect_alt/translations/nl.json
+++ b/custom_components/home_connect_alt/translations/nl.json
@@ -45,14 +45,16 @@
           "log_mode": "Verbose log mode",
           "sse_timeout": "SSE Timeout",
           "appliance_settings": "Advanced appliance settings (YAML)",
-          "entity_settings": "Advanced entity settings (YAML)"
+          "entity_settings": "Advanced entity settings (YAML)",
+          "delayed_ops": "Delayed start behavior"
         },
         "data_description": {
           "language": "Gebruik enkel [language codes](https://api-docs.home-connect.com/general/#supported-languages) ondersteund door Home Connect",
           "log_mode": "Debug logging moet aan staan in configuration.yaml voor deze setting.",
           "sse_timeout": "Timeout in minutes for refreshing the SSE connection (0=disabled)",
           "appliance_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         }
       }
     }
@@ -71,6 +73,12 @@
       "options": {
         "local": "Lokaal",
         "server": "Server"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "Use delay time span (default behavior)",
+        "absolute_time": "Use absolute time"
       }
     }
   },

--- a/custom_components/home_connect_alt/translations/pl.json
+++ b/custom_components/home_connect_alt/translations/pl.json
@@ -45,14 +45,16 @@
           "log_mode": "Verbose log mode",
           "sse_timeout": "SSE Timeout",
           "appliance_settings": "Advanced appliance settings (YAML)",
-          "entity_settings": "Advanced entity settings (YAML)"
+          "entity_settings": "Advanced entity settings (YAML)",
+          "delayed_ops": "Delayed start behavior"
         },
         "data_description": {
           "language": "Only use [language codes](https://api-docs.home-connect.com/general/#supported-languages) supported by Home Connect",
           "log_mode": "Debug logging must be enabled in configuration.yaml for this setting to apply",
           "sse_timeout": "Timeout in minutes for refreshing the SSE connection (0=disabled)",
           "appliance_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         }
       }
     }
@@ -71,6 +73,12 @@
       "options": {
         "local": "Local",
         "server": "Server"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "Use delay time span (default behavior)",
+        "absolute_time": "Use absolute time"
       }
     }
   },

--- a/custom_components/home_connect_alt/translations/sv.json
+++ b/custom_components/home_connect_alt/translations/sv.json
@@ -45,14 +45,16 @@
           "log_mode": "Verbose log mode",
           "sse_timeout": "SSE Timeout",
           "appliance_settings": "Advanced appliance settings (YAML)",
-          "entity_settings": "Advanced entity settings (YAML)"
+          "entity_settings": "Advanced entity settings (YAML)",
+          "delayed_ops": "Delayed start behavior"
         },
         "data_description": {
           "language": "Only use [language codes](https://api-docs.home-connect.com/general/#supported-languages) supported by Home Connect",
           "log_mode": "Debug logging must be enabled in configuration.yaml for this setting to apply",
           "sse_timeout": "Timeout in minutes for refreshing the SSE connection (0=disabled)",
           "appliance_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         }
       }
     }
@@ -71,6 +73,12 @@
       "options": {
         "local": "Local",
         "server": "Server"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "Use delay time span (default behavior)",
+        "absolute_time": "Use absolute time"
       }
     }
   },

--- a/custom_components/home_connect_alt/translations/zh.json
+++ b/custom_components/home_connect_alt/translations/zh.json
@@ -45,14 +45,16 @@
           "log_mode": "Verbose log mode",
           "sse_timeout": "SSE Timeout",
           "appliance_settings": "Advanced appliance settings (YAML)",
-          "entity_settings": "Advanced entity settings (YAML)"
+          "entity_settings": "Advanced entity settings (YAML)",
+          "delayed_ops": "Delayed start behavior"
         },
         "data_description": {
           "language": "Only use [language codes](https://api-docs.home-connect.com/general/#supported-languages) supported by Home Connect",
           "log_mode": "Debug logging must be enabled in configuration.yaml for this setting to apply",
           "sse_timeout": "Timeout in minutes for refreshing the SSE connection (0=disabled)",
           "appliance_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
-          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)"
+          "entity_settings": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=readme-ov-file#advanced-options)",
+          "delayed_ops": "See further details in the [README](https://github.com/ekutner/home-connect-hass?tab=handling-of-delayed-program-start)"
         }
       }
     }
@@ -71,6 +73,12 @@
       "options": {
         "local": "Local",
         "server": "Server"
+      }
+    },
+    "delayed_ops": {
+      "options": {
+        "default": "Use delay time span (default behavior)",
+        "absolute_time": "Use absolute time"
       }
     }
   },


### PR DESCRIPTION
Add support for an absolute end time setting for delayed start operation.
The idea is just to be able to set the actual time when the program should end and not worry about the delay time,  or even worse, the delay until the program starts + the duration of the program itself.
Inspired by #302