### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ In contrast, setting ```sensor_value_translation: server``` will override this b
 * **Some of my appliances are not showing up after I added the integration**  
   This is most commonly caused by two reasons:
   1. The appliance must be powered on and connected to the Home Connect service to be discovered. Once the missing devices are turned on and connected, they will automatically be discovered and added by the integration.
-  This can be verified in the Home Connect mobile app **but only while the wifi on the phone is turned OFF**. If some devices still do not show app in the integration, restart them. If the devices are active in the mobile app while the phone's wifi is turned off then please open an issue with a debug log to report it.
+  This can be verified in the Home Connect mobile app **but only while the wifi on the phone is turned OFF**. If some devices still do not show app in the integration, restart them (power cycle/unplug power cord, do not just turn them off and on). If the devices are active in the mobile app while the phone's wifi is turned off then please open an issue with a debug log to report it.
   3. Due to some unreasonable rate limits set by BSH, there is a limit of about 5
   appliances loaded per minute. If you have more, expect the initial load to take longer. The integration will wait for the service to become available and continue loading the rest of the appliances. You may have to refresh your screen to see them in Home Assistant after they were added. See more details in the next item.
 


### PR DESCRIPTION
Make it explicit that a power cycle is needed to fix a device that has partially disconnected from cloud, but still is controllable through a local network connection.