### PR TITLE
Updated README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Before installing the integration you need to create an "application" in the Hom
 3. Fill in the application creation form:  
    **Application ID**: A unique ID for the application, can be home-connect-alt, or whatever you like.  
    **OAuth Flow**: Authorization Code Grant Flow  
-   **Home Connect User Account for Testing**: Leave blank  
+   **Home Connect User Account for Testing**: Enter the account's email address  
    **Redirect URI**: https://my.home-assistant.io/redirect/oauth  
    **Add additional redirect URIs**: Leave unchecked  
    **Enable One Time Token Mode**: Leave unchecked  


### PR DESCRIPTION
Clarified the “Home Connect User Account for Testing” field in the application creation form, now specifies that the account’s email address must be entered instead of leaving it blank. 
This change was made to prevent the error:
“You have not set Default Home Connect Account for Testing in your account settings. Please provide proper Home Connect account identifier (e-mail or phone number in format +86XXXXXXXXXXX if you're located in China).”
