### PR TITLE
fix: remove hardcoded entity_id assignments

### DIFF
--- a/custom_components/home_connect_alt/button.py
+++ b/custom_components/home_connect_alt/button.py
@@ -252,7 +252,6 @@ class HomeConnectRefreshButton(ButtonEntity):
     def __init__(self, homeconnect:HomeConnect, name_suffix:str) -> None:
         self._homeconnect = homeconnect
         self._name_suffix = name_suffix
-        self.entity_id = f'home_connect.{self.unique_id}'
 
     @property
     def device_info(self):
@@ -292,7 +291,6 @@ class HomeConnectDebugButton(ButtonEntity):
     def __init__(self, homeconnect:HomeConnect, name_suffix:str) -> None:
         self._homeconnect = homeconnect
         self._name_suffix = name_suffix
-        self.entity_id = f'home_connect.{self.unique_id}'
 
     @property
     def device_info(self):

--- a/custom_components/home_connect_alt/common.py
+++ b/custom_components/home_connect_alt/common.py
@@ -41,7 +41,6 @@ class EntityBase(ABC):
         self._haid:str = ""
         self._safe_haid: str = ""
         self._unique_id:str = ""
-        self.entity_id = f'home_connect.{self.unique_id}'
         self._hc_obj = hc_obj
 
 

--- a/custom_components/home_connect_alt/sensor.py
+++ b/custom_components/home_connect_alt/sensor.py
@@ -340,7 +340,6 @@ class HomeConnectStatusSensor(SensorEntity):
     def __init__(self, homeconnect: HomeConnect, name_suffix:str) -> None:
         self._homeconnect = homeconnect
         self._name_suffix = name_suffix
-        self.entity_id = f"home_connect.{self.unique_id}"
 
     @property
     def device_info(self):


### PR DESCRIPTION
Removes the explicit `self.entity_id = f'home_connect.{self.unique_id}'` assignments from `common.py`, `sensor.py`, and `button.py`.

HA generates the correct `entity_id` automatically from the platform domain + unique ID, so these overrides are unnecessary and cause issues:

- Duplicate unique ID errors in multi-instance setups (even with `appliance_settings` correctly configured), as each instance tries to claim the same `home_connect.*` entity ID
- HA Core already flags this as deprecated and it will become a hard error in **2027.2.0** ([source](https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/entity_platform.py#L826-L832))

Closes #561