### PR TITLE
Fix RecursionError in Configuration.__merge by not aliasing _global_config with integration storage (closes #576)

### DIFF
--- a/custom_components/home_connect_alt/__init__.py
+++ b/custom_components/home_connect_alt/__init__.py
@@ -75,7 +75,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         # There is no configuration for this integration in the configuration.yaml file
         # hass.data[DOMAIN] = HC_CONFIG_SCHEMA({})
         hass.data[DOMAIN] = { "global": {} }
-        Configuration.set_global_config(hass, hass.data[DOMAIN])
+        # _global_config is merged into every per-entry Configuration in
+        # Configuration.__init__. Pass only the inner "global" dict, not
+        # the whole hass.data[DOMAIN] (which subsequent async_setup_entry
+        # calls populate with each entry's Configuration under its
+        # entry_id). Aliasing _global_config with the entry storage caused
+        # __merge to recurse into other entries' Configurations, building
+        # plain-dict shadows that compounded across reloads until Python's
+        # recursion limit was reached.
+        Configuration.set_global_config(hass, hass.data[DOMAIN]["global"])
         return True
 
     # The config now contains configuration coming from the configuration.yaml file

--- a/custom_components/home_connect_alt/common.py
+++ b/custom_components/home_connect_alt/common.py
@@ -241,12 +241,20 @@ class Configuration(dict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.update(self.__merge(self, DEFAULT_SETTINGS, overwrite=False))
+        # __merge mutates self in place and returns self; no further .update needed.
+        self.__merge(self, DEFAULT_SETTINGS, overwrite=False)
         if Configuration._global_config:
-            self.update(self.__merge(self, Configuration._global_config, overwrite=False))
+            self.__merge(self, Configuration._global_config, overwrite=False)
 
     def __merge(self, destination:dict, source:dict, overwrite:bool=True ):
         for key, value in source.items():
+            # Configuration instances are per-entry runtime storage, not config
+            # to be merged. Skipping them keeps __merge robust even if a future
+            # change re-introduces aliasing between _global_config and the
+            # integration's hass.data[DOMAIN] (the original source of the
+            # RecursionError that this guard defends against).
+            if isinstance(value, Configuration):
+                continue
             if isinstance(value, dict):
                 # get node or create one
                 node = destination.setdefault(key, {})


### PR DESCRIPTION
## Summary

Closes #576.

**Symptom.** The integration silently fails to load (or reload) — appliance entities go `unavailable` and `RecursionError: maximum recursion depth exceeded` in `Configuration.__merge` blows every `Events.PAIRED` / `Events.DATA_CHANGED` callback. Especially likely after multi-entry setups or repeated reloads.

**Cause.** In the no-YAML branch (`__init__.py:78`), `set_global_config` is called with `hass.data[DOMAIN]` itself — the integration's runtime storage. Subsequent `async_setup_entry` calls populate that same dict via `hass.data[DOMAIN][entry_id] = conf`, so every entry's `Configuration` becomes reachable as a top-level value of `_global_config`. When `Configuration.__init__` recursively merges `_global_config` into a new entry, `__merge` descends into other entries' Configurations (which are `dict` subclasses) and `setdefault(key, {})`-creates plain-dict shadow copies of their structure inside `self`. Across reloads the shadow copies compound; the 982-frame stack in #576's traceback confirms unbounded growth in practice. The `node is not value` guard added in 1.3.5 only catches direct self-reference, not the indirect aliasing.

> **The YAML branch is unaffected.** It already passes a separate `base_config` dict to `set_global_config` (line 84), not `hass.data[DOMAIN]`. Only the no-YAML path is changed by this PR.

## Fix — two commits

**Commit 1** — pass the inner `"global"` dict, not the whole storage:

```diff
-        Configuration.set_global_config(hass, hass.data[DOMAIN])
+        Configuration.set_global_config(hass, hass.data[DOMAIN]["global"])
```

That dict is the intended target for shared global config (matches the existing usage at line 116 where `CONF_API_HOST` is read/written via `hass.data[DOMAIN]["global"]`). The actual commit also lands an 8-line explanatory comment alongside the call so future readers don't have to re-derive the bug.

**Commit 2** — two follow-ups in the `Configuration` class:

1. Drop the redundant `self.update(self.__merge(...))` wrappers in `__init__`. `__merge` mutates `destination` in place and returns it, so when destination *is* `self` the wrapper is a no-op; removing it reveals the intent.
2. Defensive guard at the top of `__merge`: skip values that are themselves `Configuration` instances. With commit 1 they shouldn't reach `_global_config`, but the guard keeps the class robust to any future regression.

```diff
 def __merge(self, destination:dict, source:dict, overwrite:bool=True ):
     for key, value in source.items():
+        if isinstance(value, Configuration):
+            continue
         if isinstance(value, dict):
             ...
```

The `node is not value` guard inside `__merge` is intentionally retained — it's cheap insurance for shapes neither of us has anticipated.

## Re #576's proposed `_seen` workaround

The issue reporter's `_seen = set()` workaround correctly bounds the recursion by tracking visited `id(source)` values. Either approach is valid:

| | `_seen` set | This PR |
|---|---|---|
| Scope | Single method | Two files |
| Addresses | Recursion symptom | Aliasing root cause |
| `_global_config` semantics | Unchanged | Narrowed (see below) |
| Risk surface | Smaller | Slightly larger |

Happy to defer to the `_seen` approach if you'd prefer the more localised change. The `__merge` Configuration-skip guard in commit 2 is independent — defence in depth either way.

## User-visible behaviour change

`Configuration.get_global_config()` previously returned the whole `hass.data[DOMAIN]` dict (entries, `_options` keys, everything). After this PR it returns just the inner `"global"` dict (typically `{api_host: ...}` or `{}`).

The only consumer is `config_flow.py:185`:

```python
defaults = Configuration.get_global_config()
defaults.update(self.config_entry.options)
```

Form options come from `config_entry.options.update(...)`, which overrides anything from `_global_config`. The shape change has no functional effect on the options form, and the narrower return value is more semantically correct for a method called `get_global_config`.

## Test plan

- [x] Deployed locally on **2026-05-06** (full fix; defensive `__merge` guard alone since 2026-05-02).
- [x] **Zero** `RecursionError` and **zero** `home_connect_async.callback_registery` warnings since deployment, across multiple HA restarts, integration reloads, and a 4-config-entry split (Hood + 2 Oven cavities on one client; one dishwasher per client × 3 dishwashers).
- [x] Pre-patch evidence in logs: a burst of 77 `Unhandled exception in callback function` warnings on 2026-05-01, traceback pattern identical to #576.
- [x] No behavioural change for the YAML-config branch (verified by inspection).
- [ ] Maintainer-side: please double-check `config_flow.py`'s use of `get_global_config()` — the shape change is benign, but a second pair of eyes is welcome.

---

*Drafted with Claude Code; reviewed and validated on my running HA install before submission.*
