### PR TITLE
Replace deprecated async_get_device with async_get_device_by_identifier for HA 2027+ compatibility

### DIFF
--- a/custom_components/home_connect_alt/__init__.py
+++ b/custom_components/home_connect_alt/__init__.py
@@ -396,7 +396,7 @@ def register_events_publisher(hass:HomeAssistant, homeconnect:HomeConnect):
             last_event['key'] = key
             last_event['value'] = value
             haid = appliance.normalized_haId
-            device = device_reg.async_get_device({(DOMAIN, haid)})
+            device = device_reg.async_get_device_by_identifier((DOMAIN, haid))
             if not device:
                 haid = EntityBase.get_safe_haID(hass, appliance)
                 device = device_reg.async_get_device({(DOMAIN, haid)})


### PR DESCRIPTION
**Summary**  
This PR updates the Home Connect Alt integration to use the new Home Assistant device registry API.
The integration currently calls device_registry.async_get_device, which is deprecated and scheduled for removal in Home Assistant 2027.8.0.
Replacing it ensures long‑term compatibility and removes the deprecation warning from the logs.

**Issue**  
Home Assistant logs the following warning:
`Detected that custom integration 'home_connect_alt' calls `device_registry.async_get_device`,
which is deprecated because device identifiers and connections are no longer unique across config entries.
This will stop working in Home Assistant 2027.8.0.
`

**Fix**
`- device = device_reg.async_get_device({(DOMAIN, haid)})
+ device = device_reg.async_get_device_by_identifier((DOMAIN, haid))
`

**Notes**  
This PR prevents a future breaking change and aligns the integration with current Home Assistant standards.